### PR TITLE
fix(frontend): fix the rounding of the day's hour total

### DIFF
--- a/frontend/src/components/WorkDay/HoursTotal.tsx
+++ b/frontend/src/components/WorkDay/HoursTotal.tsx
@@ -37,22 +37,17 @@ const HoursTotal = ({ workData }: { workData: WorkBlockProps[] }) => {
       >
         {`T:  `}
 
-        {workData
-          ? (Math.round(
-              workData.reduce(
-                (acc: number, workBlock: WorkBlockProps) =>
-                  workBlock.workBlockStart && workBlock.workBlockEnd
-                    ? acc +
-                      workBlock.workBlockStart
-                        .until(workBlock.workBlockEnd)
-                        .total({ unit: 'hours' })
-                    : acc,
-                0,
-              ),
-            ) *
-              10) /
-            10
-          : 0}
+        {
+          workData ? Math.round(workData.reduce(
+            (acc: number, workBlock: WorkBlockProps) =>
+              workBlock.workBlockStart && workBlock.workBlockEnd ?
+                acc + workBlock.workBlockStart.until(workBlock.workBlockEnd).total({ unit: 'hours' })
+                :
+                acc
+            , 0
+          ) * 10) / 10
+            : 0
+        }
         {'h'}
       </Typography>
     </Box>


### PR DESCRIPTION
Fix the typo in the HoursTotal component. 

 
<details>
<summary>
Before
</summary>
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/36651ea3-413f-4da5-ab82-ddd7f0c45f09" />
</details>

<details>
<summary>
After
</summary>
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/7a9bf7e3-1419-4982-a39f-10d13f03ee21" />
</details>


Resolves #77.